### PR TITLE
Minor fixes to thr_sq and topk_sq

### DIFF
--- a/surrogate/thr_sq.py
+++ b/surrogate/thr_sq.py
@@ -27,7 +27,7 @@ def _thr_sq_encode(
         x = x.dot(rotation_matrix.T)
 
     if mean is not None:
-        x -= mean
+        x = x - mean
 
     if rectify_negatives:
         x = np.hstack([np.maximum(x, 0), - np.minimum(x, 0)])
@@ -152,7 +152,7 @@ class ThresholdSQ(SurrogateTextIndex):
 
         if self.subtract_mean:
             self.mean = x.mean(axis=0)
-            x -= self.mean
+            x = x - self.mean
 
         if self.rectify_negatives:
             x = np.fabs(x)

--- a/surrogate/thr_sq.py
+++ b/surrogate/thr_sq.py
@@ -78,7 +78,11 @@ class ThresholdSQ(SurrogateTextIndex):
                                  set this to False if vectors are already normalized.
                                  Defaults to True.
             subtract_mean (bool): whether to subtract the mean from the dataset features
-            rotation_matrix (ndarray): a (D,D)-shaped rotation matrix used to rotate dataset and query features to balance dimensions
+            rotation_matrix (ndarray or int): if ndarray: a (D,D)-shaped rotation matrix 
+                                              used to rotate dataset and query features 
+                                              to balance dimensions; if int: the random 
+                                              state used to automatically generate a random 
+                                              rotation matrix. Defaults to None.
         """
 
         self.d = d

--- a/surrogate/topk_sq.py
+++ b/surrogate/topk_sq.py
@@ -3,6 +3,7 @@ import math
 import numpy as np
 from joblib import cpu_count, delayed, Parallel
 from scipy import sparse
+from scipy.stats import ortho_group
 from sklearn.preprocessing import normalize
 
 from . import util
@@ -82,11 +83,14 @@ class TopKSQ(SurrogateTextIndex):
                                       to encode negative values separately 
                                       (a.k.a. apply CReLU transform).
                                       Defaults to True.
-            rotation_matrix (ndarray): a (D,D)-shaped rotation matrix used to rotate dataset 
-                                       and query features to balance dimensions
             l2_normalize (bool): whether to apply l2-normalization before processing vectors;
                                  set this to False if vectors are already normalized.
                                  Defaults to True.
+            rotation_matrix (ndarray or int): if ndarray: a (D,D)-shaped rotation matrix 
+                                              used to rotate dataset and query features 
+                                              to balance dimensions; if int: the random 
+                                              state used to automatically generate a random 
+                                              rotation matrix. Defaults to None.
         """
 
         self.d = d
@@ -95,6 +99,8 @@ class TopKSQ(SurrogateTextIndex):
         self.rectify_negatives = rectify_negatives
         self.l2_normalize = l2_normalize
         self.rotation_matrix = rotation_matrix
+        if isinstance(rotation_matrix, int):
+            self.rotation_matrix = ortho_group.rvs(d, random_state=rotation_matrix)
 
         vocab_size = 2 * d if self.rectify_negatives else d
         super().__init__(vocab_size, parallel)


### PR DESCRIPTION
This PR includes the following changes:
- thr_sq: percentile computation fix
- thr_sq: correct threshold for queries (the threshold is now increased by the mean of the mean vector, this should be checked mathematically)
- topk_sq: automatic random matrix generation

Also, I enhanced the documentation concerning the random matrix.

Known problems:
- Sometimes, for big datasets, using a random matrix (without mean subtraction) creates errors like `IndexError: index 524530 is out of bounds for axis 1 with size 768` when the `inverted` flag is set (most likely at [this line](https://github.com/mesnico/str-encoders/blob/54d68b8a270dc06f9648a986d31dee78897ce07e/surrogate/thr_sq.py#L134))

